### PR TITLE
Added support for LZ4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ An extension for BurpSuite used to access and modify compressed HTTP payloads wi
 
 ## Why this extension?
 Often, HTTP traffic is compressed by the server before it is sent to the client in order to reduce network load.
-Typically used algorithms are gzip or deflate. By default, BurpSuite will decompress all intercepted data in the body 
+Typically used algorithms are gzip or deflate. By default, BurpSuite will decompress all intercepted data in the body
 of HTTP messages in order to display plain text payloads in the different tabs and make stuff searchable. However, the
 content is not recompressed back before it is sent to the browser. Usually, this isn't a problem.
 
-In cases where the traffic is intended for other types of client instead of a browser, e.g. a fat/rich client using 
+In cases where the traffic is intended for other types of client instead of a browser, e.g. a fat/rich client using
 RMI over HTTP, the used content-encoding may sometimes be fixed and changing it will result in an error.
 
 ## What is it?
@@ -32,3 +32,5 @@ the burpsuite.jar in it, that you can download from [portswigger.net](https://po
 
 ## Acknowledgements
 This is my first BurpSuite extension, highly inspired by [federicodotta/BurpJDSer-ng-edited](https://github.com/federicodotta/BurpJDSer-ng-edited)
+
+LZ4 support was added by [kumzugloom](https://github.com/kumzugloom)

--- a/build.xml
+++ b/build.xml
@@ -23,15 +23,15 @@ SOFTWARE.
 -->
 
 <project name="burp-decompressor" default="dist" basedir=".">
-	
+
   <!-- set global properties for this build -->
   <property name="src" location="src"/>
   <property name="lib" location="lib"/>
   <property name="burpsuite.jar" location="${lib}/burpsuite_free_latest.jar"/>
+  <property name="lz4.jar" location="${lib}/lz4-1.3.0.jar"/>
   <property name="build" location="build"/>
   <property name="dist" location="dist"/>
 
-	
   <target name="init">
     <!-- Create the time stamp -->
     <tstamp/>
@@ -39,20 +39,25 @@ SOFTWARE.
     <mkdir dir="${build}"/>
   	<mkdir dir="${lib}"/>
   	<get src="https://portswigger.net/DownloadUpdate.ashx?Product=Free" dest="${burpsuite.jar}" skipexisting="true"/>
+  	<get src="http://central.maven.org/maven2/net/jpountz/lz4/lz4/1.3.0/lz4-1.3.0.jar" dest="${lz4.jar}" skipexisting="true"/>
   </target>
 
-	
   <target name="compile" depends="init" description="compile the source">
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac srcdir="${src}" classpath="${burpsuite.jar}" destdir="${build}"/>
+    <javac srcdir="${src}" classpath="${burpsuite.jar}" destdir="${build}">
+        <classpath>
+            <pathelement path="lib/lz4-1.3.0.jar"/>
+        </classpath>
+  	</javac>
   </target>
 
   <target name="dist" depends="compile" description="generate the distribution">
     <!-- Create the distribution directory -->
     <mkdir dir="${dist}"/>
-
-    <!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
-    <jar jarfile="${dist}/${ant.project.name}-${DSTAMP}.jar" basedir="${build}"/>
+  	<!-- Put everything in ${build} into the MyProject-${DSTAMP}.jar file -->
+    <jar jarfile="${dist}/${ant.project.name}-${DSTAMP}.jar" basedir="${build}">
+    	<zipgroupfileset dir="lib" includes="lz4-1.3.0.jar" />
+    </jar>
   </target>
 
   <target name="clean" description="clean up">

--- a/build.xml
+++ b/build.xml
@@ -39,7 +39,8 @@ SOFTWARE.
     <mkdir dir="${build}"/>
   	<mkdir dir="${lib}"/>
   	<get src="https://portswigger.net/DownloadUpdate.ashx?Product=Free" dest="${burpsuite.jar}" skipexisting="true"/>
-  	<get src="http://central.maven.org/maven2/net/jpountz/lz4/lz4/1.3.0/lz4-1.3.0.jar" dest="${lz4.jar}" skipexisting="true"/>
+  	<get src="https://repo1.maven.org/maven2/net/jpountz/lz4/lz4/1.3.0/lz4-1.3.0.jar" dest="${lz4.jar}" skipexisting="true"/>
+
   </target>
 
   <target name="compile" depends="init" description="compile the source">

--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -51,6 +51,14 @@ public class BurpExtender implements IBurpExtender {
 				return new PkzipInputTab(controller, callbacks, helpers, editable);
 			}
 		});
+		
+		// register LZ4 editor tab
+		callbacks.registerMessageEditorTabFactory(new IMessageEditorTabFactory() {
+			@Override
+			public IMessageEditorTab createNewInstance(IMessageEditorController controller, boolean editable) {
+				return new LZ4EditorTab(controller, callbacks, helpers, editable);
+			}
+		});
 
 		// register deflate editor tab
 		callbacks.registerMessageEditorTabFactory(new IMessageEditorTabFactory() {

--- a/src/burp/DeflateEditorTab.java
+++ b/src/burp/DeflateEditorTab.java
@@ -26,7 +26,7 @@ public class DeflateEditorTab extends AbstractDecompressorEditorTab implements I
 	@Override
 	public boolean detect (byte[] content) {
 		int bodyOffset = getHelpers().analyzeRequest(content).getBodyOffset();
-		return getHelpers().indexOf(content, DEFLATE_MAGIC, false, bodyOffset, bodyOffset + DEFLATE_MAGIC.length) > -1;
+		return getHelpers().indexOf(content, DEFLATE_MAGIC, false, bodyOffset, content.length) > -1;
 	}
 
 	@Override

--- a/src/burp/GzipEditorTab.java
+++ b/src/burp/GzipEditorTab.java
@@ -54,7 +54,7 @@ class GzipEditorTab extends AbstractDecompressorEditorTab implements IMessageEdi
 	@Override
 	protected boolean detect(byte[] content) {
 		int bodyOffset = getHelpers().analyzeRequest(content).getBodyOffset();
-		return getHelpers().indexOf(content, GZIP_MAGIC, true, bodyOffset, bodyOffset + GZIP_MAGIC.length) > -1;
+		return getHelpers().indexOf(content, GZIP_MAGIC, true, bodyOffset, content.length) > -1;
 	}
 
 

--- a/src/burp/LZ4EditorTab.java
+++ b/src/burp/LZ4EditorTab.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Antoine Neuenschwander
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package burp;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+
+import net.jpountz.lz4.LZ4BlockInputStream;
+import net.jpountz.lz4.LZ4BlockOutputStream;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+import net.jpountz.lz4.LZ4SafeDecompressor;
+
+
+/**
+ * Uncompresses LZ4ped data for display in the message editor tab.
+ * Compresses data in LZ4 format after manipulation.
+ */
+class LZ4EditorTab extends AbstractDecompressorEditorTab implements IMessageEditorTab {
+
+	// public static final byte[] LZ4_MAGIC = {(byte) 0x18, (byte)0x4d, (byte)0x22, (byte) 0x04};
+	
+	// LZ4 Block Stream Magic Byte
+	public static final byte[] LZ4_MAGIC  = {(byte)0x4c, (byte)0x5a , (byte)0x34, (byte)0x42, (byte)0x6c, (byte)0x6f, (byte)0x63, (byte)0x6b};
+
+	public LZ4EditorTab(IMessageEditorController controller, IBurpExtenderCallbacks callbacks,
+			IExtensionHelpers helpers, 	boolean editable) {
+		super(controller, callbacks, helpers, editable);
+	}
+
+
+	public String getTabCaption() {
+		return "LZ4 Data";
+	}
+
+	@Override
+	protected boolean detect(byte[] content) {
+		int bodyOffset = getHelpers().analyzeRequest(content).getBodyOffset();
+		return getHelpers().indexOf(content, LZ4_MAGIC, true, bodyOffset, content.length) > -1;
+	}
+
+	@Override
+	protected byte[] decompress(byte[] content) throws IOException {
+		
+		int bodyOffset = getHelpers().analyzeRequest(content).getBodyOffset();
+		
+		byte[] compressed = Arrays.copyOfRange(content, bodyOffset, content.length);
+		ByteArrayInputStream bis = new ByteArrayInputStream(compressed);
+		LZ4BlockInputStream is = new LZ4BlockInputStream(bis);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		byte[] buffer = new byte[1024];
+		int bytes_read;
+
+		while ((bytes_read = is.read(buffer)) > 0) {
+			baos.write(buffer, 0, bytes_read);
+		}
+		baos.close();
+		is.close();
+		return baos.toByteArray();
+		
+	}
+	
+	@Override
+	protected byte[] compress(byte[] content) throws IOException {
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		LZ4BlockOutputStream os = new LZ4BlockOutputStream(baos);
+		
+		os.write(content);
+		os.flush();
+		os.close();
+		baos.close();
+		return baos.toByteArray();
+			
+	}
+
+}

--- a/src/burp/PkzipInputTab.java
+++ b/src/burp/PkzipInputTab.java
@@ -36,7 +36,7 @@ import java.util.zip.ZipOutputStream;
 public class PkzipInputTab extends AbstractDecompressorEditorTab implements IMessageEditorTab {
 
 	public static final byte[] PKZIP_MAGIC = { (byte) 0x50, (byte) 0x4b, (byte) 0x03, (byte) 0x04 };
-	
+
 	/** current zipentry. */
 	private String zipEntry = "";
 
@@ -56,7 +56,7 @@ public class PkzipInputTab extends AbstractDecompressorEditorTab implements IMes
 	@Override
 	public boolean detect (byte[] content) {
 		int bodyOffset = getHelpers().analyzeRequest(content).getBodyOffset();
-		return getHelpers().indexOf(content, PKZIP_MAGIC, false, bodyOffset, bodyOffset + PKZIP_MAGIC.length) > -1;
+		return getHelpers().indexOf(content, PKZIP_MAGIC, false, bodyOffset, content.length) > -1;
 	}
 
 


### PR DESCRIPTION
Hi, during a recent project I required a LZ4-decompression-plugin. Your decompressor was a useful template, that I extended. 
Additionally I had to fix an error in the detect methods. When loading the fresh built version into the extender of a current burp (1.6 up to 1.7.x), it was throwing NullPointerExceptions.
Feel free to merge, if you like.
Cheers,
kumzugloom